### PR TITLE
bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:2.6
+FROM ruby:2.6.5-alpine
+
+RUN apk add --update build-base git
 
 LABEL com.github.actions.name="Rubocop Linter"
 LABEL com.github.actions.description="Lint your Ruby code"
@@ -8,4 +10,6 @@ LABEL com.github.actions.color="red"
 LABEL maintainer="Andrew Mason <andrewmcodes@protonmail.com>"
 
 COPY lib /action/lib
+RUN gem install bundler
+
 ENTRYPOINT ["/action/lib/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 # Rubocop Linter Action
 
-![version number](https://img.shields.io/static/v1?label=Version&message=v0.1.2&color=blue)
+![version number](https://img.shields.io/static/v1?label=Version&message=v0.2.0&color=blue)
 
-GitHub Action to run Rubocop against your code.
+GitHub Action to run Rubocop against your code and create annotations in the UI.
+
+**NOTE: due to the GitHub Check Runs API, we can only return 50 annotations per run. See [here](https://developer.github.com/v3/checks/runs/#output-object) for more info.**
 
 ## Usage
 
@@ -12,7 +14,7 @@ Add the following to your GitHub action workflow:
 
 ```yaml
 - name: Rubocop Linter
-  uses: andrewmcodes/rubocop-linter-action@v0.1.2
+  uses: andrewmcodes/rubocop-linter-action@v0.2.0
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -20,27 +22,23 @@ Add the following to your GitHub action workflow:
 ## Example Workflow
 
 ```yaml
-name: Ruby
+name: Rubocop
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - master
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.6.x
-    - name: add PostgreSQL dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y postgresql-client libpq-dev
     - name: Rubocop Linter
-      uses: andrewmcodes/rubocop-linter-action@v0.1.2
+      uses: andrewmcodes/rubocop-linter-action@v0.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-gem install rubocop rubocop-performance rubocop-rails
+gem install rubocop rubocop-performance rubocop-rails rubocop-minitest rubocop-rspec
 
 ruby /action/lib/index.rb


### PR DESCRIPTION
# Bug Fix

## Description

Fix `Unprocessable Entity (RuntimeError)` error when trying to run the action. The issue is the Checks API limits you to creating 50 annotations and where this error was occurring is where there were more than 50 rubocop errors. The action will now stop adding annotations at 50.

Fixes #16 & #17

## Checklist

- [x] My code follows the style guidelines of this project
