### PR TITLE
Do not send in an empty array of annotations on success

### DIFF
--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -19,6 +19,7 @@ class GithubCheckRunService
     @annotations = @report_adapter.annotations(@report)
     @conclusion = @report_adapter.conslusion(@report)
 
+    puts update_check_payload
     @client.patch(
       "#{endpoint_url}/#{id}",
       update_check_payload

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -47,14 +47,12 @@ class GithubCheckRunService
 
   def update_check_payload
     base_payload('completed').merge!(
-      {
-        conclusion: @conclusion,
-        output: {
-          title: CHECK_NAME,
-          summary: @summary,
-          annotations: (@annotations if @conclusion == 'failure')
-        }.compact
-      }
+      conclusion: @conclusion,
+      output: {
+        title: CHECK_NAME,
+        summary: @summary,
+        annotations: (@annotations if @conclusion == 'failure')
+      }.compact
     )
   end
 end

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -19,7 +19,6 @@ class GithubCheckRunService
     @annotations = @report_adapter.annotations(@report)
     @conclusion = @report_adapter.conslusion(@report)
 
-    puts update_check_payload
     @client.patch(
       "#{endpoint_url}/#{id}",
       update_check_payload

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -52,8 +52,9 @@ class GithubCheckRunService
         output: {
           title: CHECK_NAME,
           summary: @summary,
-        }.merge!({ annotations: @annotations } if @conclusion == 'failure')
-      }
+          annotations: (@annotations if @conclusion == 'failure')
+        }
+      }.compact
     )
   end
 end

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -32,27 +32,28 @@ class GithubCheckRunService
     "/repos/#{@github_data[:owner]}/#{@github_data[:repo]}/check-runs"
   end
 
-  def create_check_payload
+  def base_payload(status)
     {
       name: CHECK_NAME,
       head_sha: @github_data[:sha],
-      status: 'in_progress',
+      status: status,
       started_at: Time.now.iso8601
     }
   end
 
+  def create_check_payload
+    base_payload('in_progress')
+  end
+
   def update_check_payload
-    {
-      name: CHECK_NAME,
-      head_sha: @github_data[:sha],
-      status: 'completed',
-      completed_at: Time.now.iso8601,
-      conclusion: @conclusion,
-      output: {
-        title: CHECK_NAME,
-        summary: @summary,
-        annotations: @annotations
+    base_payload('completed').merge!(
+      {
+        conclusion: @conclusion,
+        output: {
+          title: CHECK_NAME,
+          summary: @summary,
+        }.merge!({ annotations: @annotations } if @conclusion == 'failure')
       }
-    }
+    )
   end
 end

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -53,8 +53,8 @@ class GithubCheckRunService
           title: CHECK_NAME,
           summary: @summary,
           annotations: (@annotations if @conclusion == 'failure')
-        }
-      }.compact
+        }.compact
+      }
     )
   end
 end


### PR DESCRIPTION
# Bug Fix

## Description

GitHub's API requires that all annotations have a start and end on line parameter. Currently, we are passing in an array of empty annotations, which causes the API to error. This corrects that issue by not merging in annotations to the update check payload unless the status is failure.

Fixes #28

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
