### PR TITLE
only send GitHub offenses instead of entire json output

### DIFF
--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -53,7 +53,7 @@ class GithubCheckRunService
         title: CHECK_NAME,
         summary: @summary,
         annotations: @annotations
-      }.compact
+      }
     )
   end
 end

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -19,8 +19,6 @@ class GithubCheckRunService
     @annotations = @report_adapter.annotations(@report)
     @conclusion = @report_adapter.conclusion(@report)
 
-    puts update_check_payload
-
     @client.patch(
       "#{endpoint_url}/#{id}",
       update_check_payload

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -11,15 +11,15 @@ class GithubCheckRunService
   end
 
   def run
-    id = @client.post(
+    x = @client.post(
       endpoint_url,
       create_check_payload
-    )['id']
+    )
+    puts x
+    id = x['id']
     @summary = @report_adapter.summary(@report)
     @annotations = @report_adapter.annotations(@report)
     @conclusion = @report_adapter.conclusion(@report)
-
-    puts update_check_payload
 
     @client.patch(
       "#{endpoint_url}/#{id}",

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -52,7 +52,7 @@ class GithubCheckRunService
       output: {
         title: CHECK_NAME,
         summary: @summary,
-        annotations: (@annotations if @conclusion == 'failure')
+        annotations: @annotations
       }.compact
     )
   end

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -19,6 +19,8 @@ class GithubCheckRunService
     @annotations = @report_adapter.annotations(@report)
     @conclusion = @report_adapter.conclusion(@report)
 
+    puts update_check_payload
+
     @client.patch(
       "#{endpoint_url}/#{id}",
       update_check_payload

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -11,15 +11,15 @@ class GithubCheckRunService
   end
 
   def run
-    x = @client.post(
+    id = @client.post(
       endpoint_url,
       create_check_payload
-    )
-    puts x
-    id = x['id']
+    )['id']
     @summary = @report_adapter.summary(@report)
     @annotations = @report_adapter.annotations(@report)
     @conclusion = @report_adapter.conclusion(@report)
+
+    puts update_check_payload
 
     @client.patch(
       "#{endpoint_url}/#{id}",

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -44,6 +44,7 @@ class ReportAdapter
           )
         end
       end
+      return annotation_list
     end
 
     private

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -44,7 +44,7 @@ class ReportAdapter
           )
         end
       end
-      return annotation_list
+      annotation_list
     end
 
     private


### PR DESCRIPTION
# Bug Fix

## Description

We were not actually sending GitHub our list of annotations, but rather the entire report generated from `rubocop --format json`. This caused there to be empty offenses in the annotations we were trying to create, which the API rejected due to missing keys.

This change ensures that we actually send our annotation list, instead of the entire report. This also negated the need for the changes in #29, which have also been removed.

Fixes #40

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
