### PR TITLE
Use 'notice' annotation style for refactor + convention offenses

### DIFF
--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -4,8 +4,8 @@ class ReportAdapter
   class << self
     CONCLUSION_TYPES = { failure: 'failure', success: 'success' }.freeze
     ANNOTATION_LEVELS = {
-      'refactor' => 'failure',
-      'convention' => 'failure',
+      'refactor' => 'notice',
+      'convention' => 'notice',
       'warning' => 'warning',
       'error' => 'failure',
       'fatal' => 'failure'

--- a/spec/report_adapter_spec.rb
+++ b/spec/report_adapter_spec.rb
@@ -28,7 +28,7 @@ describe ReportAdapter do
         'end_line' => 1,
         'start_column' => 1,
         'end_column' => 1,
-        'annotation_level' => 'failure',
+        'annotation_level' => 'notice',
         'message' => 'Missing magic comment `# frozen_string_literal: true`.'
       )
     end
@@ -41,7 +41,7 @@ describe ReportAdapter do
         'path' => 'Gemfile',
         'start_line' => 50,
         'end_line' => 65,
-        'annotation_level' => 'failure',
+        'annotation_level' => 'notice',
         'message' => 'Method has too many lines. [15/10]'
       )
     end


### PR DESCRIPTION

# Type of PR (feature, enhancement, bug fix, etc.)
enhancement

## Description

This modifies the annotation type used for `convention` and `refactor` offenses to `notice`. The resulting annotations look like this:

<img width="410" alt="image" src="https://user-images.githubusercontent.com/13192/68835557-2fb7d480-066d-11ea-9b21-909123cfd8a8.png">

## Why should this be added

This better aligns with the default Rubocop behavior and reporting in the HTML foratter:

- refactor and convention are treated as something to know about
- warnings are treated as warnings
- error and fatal are treated as problems

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
