### PR TITLE
Add cop name to report messages

### DIFF
--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -39,7 +39,7 @@ class ReportAdapter
               'start_column': (location['start_column'] if same_line),
               'end_column': (location['last_column'] if same_line),
               'annotation_level': annotation_level(offense['severity']),
-              'message': offense['message']
+              'message': "#{offense['message']} [#{offense['cop_name']}]"
             }.compact.transform_keys!(&:to_s)
           )
         end

--- a/spec/report_adapter_spec.rb
+++ b/spec/report_adapter_spec.rb
@@ -29,7 +29,7 @@ describe ReportAdapter do
         'start_column' => 1,
         'end_column' => 1,
         'annotation_level' => 'failure',
-        'message' => 'Missing magic comment `# frozen_string_literal: true`.'
+        'message' => 'Missing magic comment `# frozen_string_literal: true`. [Style/FrozenStringLiteralComment]'
       )
     end
   end
@@ -42,7 +42,7 @@ describe ReportAdapter do
         'start_line' => 50,
         'end_line' => 65,
         'annotation_level' => 'failure',
-        'message' => 'Method has too many lines. [15/10]'
+        'message' => 'Method has too many lines. [15/10] [Metrics/MethodLength]'
       )
     end
   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

## Description

Add cop names to the report. Here's what it looks like:

<img width="548" alt="image" src="https://user-images.githubusercontent.com/438465/68896728-bb734480-06f1-11ea-8b0d-b19158379fdc.png">

Fixes #47

## Why should this be added

It's often hard to track down why an issue happened without knowing the cop name for more details. Some of the error messages are quite hard to search for on the internet, and sometimes guessing what Rubocop expects is an exercise in futility.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing