### PR TITLE
Bash script fixes

### DIFF
--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ "${INPUT_BUNDLE}" == "true" ]
 then
-  bundle install --jobs 4 --retry 3
+  bundle install --deployment --jobs 4 --retry 3
 elif [ -z "${INPUT_VERSION}" ]
 then
   gem install rubocop ${INPUT_ADDITIONAL_GEMS}

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-if ["${INPUT_BUNDLE}" == "true"]
+if [ "${INPUT_BUNDLE}" == "true" ]
 then
   bundle install --jobs 4 --retry 3
-elif ["${INPUT_VERSION}" != ""]
+elif [ -z "${INPUT_VERSION}" ]
 then
   gem install rubocop ${INPUT_ADDITIONAL_GEMS}
 else


### PR DESCRIPTION
# Bug fix

## Description

The new bash script had a couple of errors.

1. Syntax error in the bundle check line
1. bundle was not using the `--deployment` flag, which is used for CI, and puts gems into `vendor/bundle`, which allows GitHub `actions/cache` to cache it.

## Why should this be added

The current script has a syntax error on line five and breaks, and bundle assets cannot be cached.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Actions are passing
