### PR TITLE
Bugfix/respect rubocop level

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -25,13 +25,13 @@ end
 @rubocop += ' --fail-level ' + ENV['INPUT_FAIL_LEVEL']
 
 cmd_sysout = `#{@rubocop}`
-cmd_result = $?
+cmd_result = $?.to_i
 @report =
   if ENV['REPORT_PATH']
     read_json(ENV['REPORT_PATH'])
   else
     Dir.chdir(ENV['GITHUB_WORKSPACE']) { JSON.parse(cmd_sysout) }
   end
-@report['__exit_code'] = cmd_result.exit_code
+@report['__exit_code'] = cmd_result
 
 GithubCheckRunService.new(@report, @github_data, ReportAdapter).run

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -32,6 +32,6 @@ cmd_result = $?
   else
     Dir.chdir(ENV['GITHUB_WORKSPACE']) { JSON.parse(cmd_sysout) }
   end
-@report['__exit_code'] = cmd_result
+@report['__exit_code'] = cmd_result.exit_code
 
 GithubCheckRunService.new(@report, @github_data, ReportAdapter).run

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -25,7 +25,10 @@ end
 @rubocop += ' --fail-level ' + ENV['INPUT_FAIL_LEVEL']
 
 cmd_sysout = `#{@rubocop}`
+# Sorry, I'm a purist and $? is well understood without requiring anything.
+# rubocop:disable Style/SpecialGlobalVars
 cmd_result = $?.to_i
+# rubocop:enable Style/SpecialGlobalVars
 @report =
   if ENV['REPORT_PATH']
     read_json(ENV['REPORT_PATH'])

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -24,11 +24,14 @@ end
 @rubocop += ' --except ' + ENV['INPUT_EXCLUDED_COPS'] if ENV['INPUT_EXCLUDED_COPS'] != ''
 @rubocop += ' --fail-level ' + ENV['INPUT_FAIL_LEVEL']
 
+cmd_sysout = `#{@rubocop}`
+cmd_result = $?
 @report =
   if ENV['REPORT_PATH']
     read_json(ENV['REPORT_PATH'])
   else
-    Dir.chdir(ENV['GITHUB_WORKSPACE']) { JSON.parse(`#{@rubocop}`) }
+    Dir.chdir(ENV['GITHUB_WORKSPACE']) { JSON.parse(cmd_sysout) }
   end
+@report['__exit_code'] = cmd_result
 
 GithubCheckRunService.new(@report, @github_data, ReportAdapter).run

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -60,6 +60,5 @@ class ReportAdapter
     def status_code(report)
       report.dig('__exit_code')
     end
-
   end
 end

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -12,7 +12,7 @@ class ReportAdapter
     }.freeze
 
     def conclusion(report)
-      return CONCLUSION_TYPES[:failure] if total_offenses(report).positive?
+      return CONCLUSION_TYPES[:failure] if status_code(report).positive?
 
       CONCLUSION_TYPES[:success]
     end
@@ -56,5 +56,10 @@ class ReportAdapter
     def total_offenses(report)
       report.dig('summary', 'offense_count')
     end
+
+    def status_code(report)
+      report.dig('__exit_code')
+    end
+
   end
 end

--- a/spec/fixtures/report.json
+++ b/spec/fixtures/report.json
@@ -1,4 +1,5 @@
 {
+  "__exit_code": 1,
   "metadata": {
     "rubocop_version": "0.75.1",
     "ruby_engine": "ruby",

--- a/spec/github_check_run_service_spec.rb
+++ b/spec/github_check_run_service_spec.rb
@@ -9,10 +9,10 @@ describe GithubCheckRunService do
 
   it '#run' do
     stub_request(:any, 'https://api.github.com/repos/owner/repository_name/check-runs/id')
-      .to_return(status: 200, body: '{}')
+      .to_return(status: 200, body: '{"__exit_code":0}')
 
     stub_request(:any, 'https://api.github.com/repos/owner/repository_name/check-runs')
-      .to_return(status: 200, body: '{"id": "id"}')
+      .to_return(status: 200, body: '{"id": "id", "__exit_code":1}')
 
     output = service.run
     expect(output).to be_a(Hash)

--- a/spec/report_adapter_spec.rb
+++ b/spec/report_adapter_spec.rb
@@ -9,7 +9,13 @@ describe ReportAdapter do
 
   let(:adapter) { ReportAdapter }
 
-  it '.conclusion' do
+  it '.conclusion_happy' do
+    rubocop_report['__exit_code'] = 0
+    result = adapter.conclusion(rubocop_report)
+    expect(result).to eq('success')
+  end
+
+  it '.conclusion_failure' do
     result = adapter.conclusion(rubocop_report)
     expect(result).to eq('failure')
   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bugfix

## Description

Pass the exit code of the Rubocop run in the report as a synthetic JSON entry. Check it and respect it.

Fixes # (issue)

https://github.com/andrewmcodes/rubocop-linter-action/issues/63

## Why should this be added

This respects whichever behavior Rubocop chooses to do to fail the check on --fail-level. Rubocop's semantics do not use the report output for this, but instead set the process status code because they are usually part of a build process.

## Checklist

- [?] My code follows the style guidelines of this project
- [X] Actions are passing
