### PR TITLE
fix obsolete configuration error in rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Metrics/MethodLength:


### PR DESCRIPTION
# Bug Fix

## Description

We have an obsolete configuration error in the rubocop config. This updates it to the changed value.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
