### PR TITLE
only push to the playground repo on push

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,17 @@
+name: Dispatch
+
+on: push
+
+jobs:
+  dispatch:
+    name: Update playground
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+        repository: andrewmcodes/rubocop-linter-action-playground
+        event-type: rubocop-linter-action-test
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "actor": "${{ github.actor }}"}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,15 +24,3 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run Rspec
       run: bin/rspec
-  dispatch:
-    name: Update playground
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Repository Dispatch
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
-        repository: andrewmcodes/rubocop-linter-action-playground
-        event-type: rubocop-linter-action-test
-        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "actor": "${{ github.actor }}"}'


### PR DESCRIPTION
# Bug Fix

## Description

Only dispatch to the playground repo on push.

## Why should this be added

Forked repos don't have access to the required env variable so there is no sense in running it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
