### PR TITLE
Create initial GitHub check before running rubocop

### DIFF
--- a/lib/github/check_run_service.rb
+++ b/lib/github/check_run_service.rb
@@ -2,7 +2,7 @@
 
 module Github
   class CheckRunService
-    attr_reader :report, :github_data, :report_adapter, :check_name
+    attr_reader :report, :github_data, :report_adapter, :check_name, :results
 
     def initialize(report: nil, github_data: nil, report_adapter: nil, check_name: nil)
       @report = report
@@ -17,6 +17,8 @@ module Github
         create_check_payload
       )['id']
 
+      @results = report.build
+
       client.patch(
         "#{endpoint_url}/#{id}",
         update_check_payload
@@ -30,15 +32,15 @@ module Github
     end
 
     def summary
-      report_adapter.summary(report)
+      report_adapter.summary(results)
     end
 
     def annotations
-      report_adapter.annotations(report)
+      report_adapter.annotations(results)
     end
 
     def conclusion
-      report_adapter.conclusion(report)
+      report_adapter.conclusion(results)
     end
 
     def endpoint_url

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -47,7 +47,7 @@ class RubocopLinterAction
   end
 
   def report
-    Report.new(github_data, command).build
+    Report.new(github_data, command)
   end
 
   def run_check_run_service

--- a/spec/github_check_run_service_spec.rb
+++ b/spec/github_check_run_service_spec.rb
@@ -3,7 +3,7 @@
 require './spec/spec_helper'
 
 describe Github::CheckRunService do
-  let(:rubocop_report) { JSON(File.read('./spec/fixtures/report.json')) }
+  let(:rubocop_report) { double(build: JSON(File.read('./spec/fixtures/report.json'))) }
   let(:github_data) { Github::Data.new(event) }
   subject do
     Github::CheckRunService.new(


### PR DESCRIPTION
## Type of PR (feature, enhancement, bug fix, etc.)

enhancement

## Description

Previously, rubocop was run first and the results were passed to the `GithubCheckRunService`.
This change means the in-progress check is created before the rubocop run starts and then
updated once results are available.

## Why should this be added

Improves user feedback about check runs.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
