### PR TITLE
Ensure start_column comes before end_column

### DIFF
--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -31,6 +31,10 @@ class ReportAdapter
 
           location = offense['location']
           same_line = location['start_line'] == location['last_line']
+          has_columns = location['start_column'] && location['end_column']
+          if same_line && has_columns && location['start_column'] < location['end_column']
+            location['start_column'], location['end_column'] = location['end_column'], location['start_column']
+          end
           annotation_list.push(
             {
               'path': file['path'],

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -21,7 +21,7 @@ class ReportAdapter
       "#{total_offenses(report)} offense(s) found."
     end
 
-    def annotations(report) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def annotations(report) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       annotation_list = []
       count = 0
       report['files'].each do |file|


### PR DESCRIPTION
## Type of PR (feature, enhancement, bug fix, etc.)

bug fix

## Description

On rare occasions (like the TrailingEmptyLines cop checking for newlines at the end of a file),
rubocop can generate a start column that's larger than the end column and also report both of
these as being on the same line. 

## Why should this be added

GitHub rejects annotations where `start_column` is greater than `end_column`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
