### PR TITLE
Work around 50-annotation limit by making multiple update calls

### DIFF
--- a/lib/github/check_run_service.rb
+++ b/lib/github/check_run_service.rb
@@ -17,10 +17,15 @@ module Github
         create_check_payload
       )['id']
 
-      client.patch(
-        "#{endpoint_url}/#{id}",
-        update_check_payload
-      )
+      last_result = nil
+      annotations.each_slice(48) do |annotations_slice|
+        last_result = client.patch(
+          "#{endpoint_url}/#{id}",
+          update_check_payload(annotations_slice)
+        )
+      end
+
+      last_result
     end
 
     private
@@ -58,7 +63,7 @@ module Github
       base_payload('in_progress')
     end
 
-    def update_check_payload
+    def update_check_payload(annotations)
       base_payload('completed').merge!(
         conclusion: conclusion,
         output: {

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -22,15 +22,11 @@ class ReportAdapter
     end
 
     def annotations(report) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      annotation_list = []
-      count = 0
-      report['files'].each do |file|
+      report['files'].each_with_object([]) do |file, annotation_list|
         file['offenses'].each do |offense|
-          count += 1
-          return annotation_list if count == 48
-
           location = offense['location']
           same_line = location['start_line'] == location['last_line']
+
           annotation_list.push(
             {
               'path': file['path'],
@@ -44,7 +40,6 @@ class ReportAdapter
           )
         end
       end
-      annotation_list
     end
 
     private


### PR DESCRIPTION


## Type of PR (feature, enhancement, bug fix, etc.)

enhancement

## Description

Per https://developer.github.com/v3/checks/runs/#output-object-1, we can
make multiple update calls and each set of annotations will be appended
to the existing ones. This means we can remove the limit on
ReportAdapter#annotations output and spread the output across multiple
update calls in the GitHubCheckRunService.

## Why should this be added

More annotations are clearly better 😛 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
