### PR TITLE
ReportAdapter#column_check correctly parses the last_column value

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   rubocop:
-    name: Ruocop Action
+    name: RuboCop Action
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -44,10 +44,10 @@ class ReportAdapter
 
     def column_check(location)
       same_line = location["start_line"] == location["last_line"]
-      has_columns = location["start_column"] && location["end_column"]
+      has_columns = location["start_column"] && location["last_column"]
 
-      if same_line && has_columns && location["start_column"] < location["end_column"]
-        location["start_column"], location["end_column"] = location["end_column"], location["start_column"]
+      if same_line && has_columns && location["start_column"] > location["last_column"]
+        location["start_column"], location["last_column"] = location["last_column"], location["start_column"]
       end
 
       [location, same_line]

--- a/spec/fixtures/report.json
+++ b/spec/fixtures/report.json
@@ -28,6 +28,21 @@
         },
         {
           "severity": "convention",
+          "message": "Final newline missing.",
+          "cop_name": "Layout/TrailingBlankLines",
+          "corrected": false,
+          "location" :{
+            "start_line": 15,
+            "start_column": 4,
+            "last_line": 15,
+            "last_column": 3,
+            "length": 0,
+            "line": 15,
+            "column": 4
+          }
+        },
+        {
+          "severity": "convention",
           "message": "Method has too many lines. [15/10]",
           "cop_name": "Metrics/MethodLength",
           "corrected": false,

--- a/spec/report_adapter_spec.rb
+++ b/spec/report_adapter_spec.rb
@@ -3,8 +3,9 @@
 require "./spec/spec_helper"
 
 describe ReportAdapter do
-  let(:rubocop_report) { JSON(File.read("./spec/fixtures/report.json")) }
   subject { ReportAdapter }
+
+  let(:rubocop_report) { JSON(File.read("./spec/fixtures/report.json")) }
 
   context "when exit code is 0" do
     it "succeedes" do
@@ -34,12 +35,27 @@ describe ReportAdapter do
         "message" => "Missing magic comment `# frozen_string_literal: true`. [Style/FrozenStringLiteralComment]"
       )
     end
+
+    context "when the start_column is larger than the end_column" do
+      it "sets the end_column to the same value as start_column" do
+        result = subject.annotations(rubocop_report)
+        expect(result[1]).to eq(
+          "path" => "Gemfile",
+          "start_line" => 15,
+          "end_line" => 15,
+          "start_column" => 3,
+          "end_column" => 4,
+          "annotation_level" => "notice",
+          "message" => "Final newline missing. [Layout/TrailingBlankLines]"
+        )
+      end
+    end
   end
 
   context "when error is not on the same line" do
     it "does not have start and end column keys" do
       result = subject.annotations(rubocop_report)
-      expect(result[1]).to eq(
+      expect(result[2]).to eq(
         "path" => "Gemfile",
         "start_line" => 50,
         "end_line" => 65,

--- a/spec/report_adapter_spec.rb
+++ b/spec/report_adapter_spec.rb
@@ -3,7 +3,7 @@
 require "./spec/spec_helper"
 
 describe ReportAdapter do
-  subject { ReportAdapter }
+  subject { described_class }
 
   let(:rubocop_report) { JSON(File.read("./spec/fixtures/report.json")) }
 


### PR DESCRIPTION
# Bug fix

## Description

This PR changes the `ReportAdapter#column_check` implementation to look for the `last_column` value on the RuboCop report, instead of `end_column` (that's the key used on the GitHub API). It also inverts the direction of the comparison operator being used to apply the fix.

Some minor improvements to the spec file were added as well.

## Why should this be added

Fixes #91

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
