### PR TITLE
Enhanced dependency configuration and resolution

### DIFF
--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -3,20 +3,16 @@
 # Default: 'Rubocop Action'
 check_name: "Rubocop Results"
 
-# Description: Version of rubocop that will be installed.
-# Valid options: 'latest' or a version number like '0.75.0'.
-# Default: 'latest'
-rubocop_version: 'latest'
-
-# Description: Extensions required to run your rubocop config.
-# Valid options: Any rubocop extension, by default the latest gem version will be used. You can explicitly state that
-# (not required) or use a version number like '1.5.1'.
+# Description: Versions required to run your RuboCop checks.
+# Valid options: RuboCop and any RuboCop extension, by default the latest gem version will be used. You can explicitly state that
+# (not required) or use a version number like 1.5.1.
 # Default: nil
-rubocop_extensions:
-  - 'rubocop-rails'
-  - 'rubocop-performance': '1.5.1'
-  - 'rubocop-minitest': 'latest'
-  - 'rubocop-rspec': '1.37.0'
+versions:
+  - rubocop
+  - rubocop-rails
+  - rubocop-minitest
+  - rubocop-performance: 1.5.1
+  - rubocop-rspec: 1.37.0
 
 # Description: Rubocop configuration file path relative to the workspace.
 # Valid options: A valid file path inside of the workspace.

--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -1,18 +1,20 @@
 # Description: The name of the check that will be created.
 # Valid Options: A reasonably sized string.
 # Default: 'Rubocop Action'
-check_name: "Rubocop Results"
+check_name: 'Rubocop Results'
 
 # Description: Versions required to run your RuboCop checks.
 # Valid options: RuboCop and any RuboCop extension, by default the latest gem version will be used. You can explicitly state that
-# (not required) or use a version number like 1.5.1.
-# Default: nil
+# (not required) or use a version number, like '1.5.1'.
+# Default:
+#   versions:
+#     - rubocop: 'latest'
 versions:
   - rubocop
   - rubocop-rails
   - rubocop-minitest
-  - rubocop-performance: 1.5.1
-  - rubocop-rspec: 1.37.0
+  - rubocop-performance: '1.5.1'
+  - rubocop-rspec: '1.37.0'
 
 # Description: Rubocop configuration file path relative to the workspace.
 # Valid options: A valid file path inside of the workspace.
@@ -36,7 +38,7 @@ rubocop_fail_level: 'warning'
 
 # Instead of installing gems from rubygems, we can run `bundle install` on your project,
 # you would need to do this if you are using something like 'rubocop-github' or if you don't
-# want to list out extensions with the `rubocop_extensions` key.
+# want to list out dependencies with the `versions` key.
 # Valid options: true || false
 # Default: false
 bundle: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,22 +10,20 @@ We use a configuration file to configure the action. This allows us to have a ve
 # Description: The name of the check that will be created.
 # Valid Options: A reasonably sized string.
 # Default: 'Rubocop Action'
-check_name: "Rubocop Results"
+check_name: 'Rubocop Results'
 
-# Description: Version of rubocop that will be installed.
-# Valid options: 'latest' or a version number like '0.75.0'.
-# Default: 'latest'
-rubocop_version: 'latest'
-
-# Description: Extensions required to run your rubocop config.
-# Valid options: Any rubocop extension, by default the latest gem version will be used. You can explicitly state that
-# (not required) or use a version number like '1.5.1'.
-# Default: nil
-rubocop_extensions:
-  - 'rubocop-rails'
-  - 'rubocop-performance': '1.5.1'
-  - 'rubocop-minitest': 'latest'
-  - 'rubocop-rspec': '1.37.0'
+# Description: Versions required to run your RuboCop checks.
+# Valid options: RuboCop and any RuboCop extension, by default the latest gem version will be used. You can explicitly state that
+# (not required) or use a version number, like '1.5.1'.
+# Default:
+#   versions:
+#     - rubocop: 'latest'
+versions:
+  - rubocop
+  - rubocop-rails
+  - rubocop-minitest
+  - rubocop-performance: '1.5.1'
+  - rubocop-rspec: '1.37.0'
 
 # Description: Rubocop configuration file path relative to the workspace.
 # Valid options: A valid file path inside of the workspace.
@@ -49,7 +47,7 @@ rubocop_fail_level: 'warning'
 
 # Instead of installing gems from rubygems, we can run `bundle install` on your project,
 # you would need to do this if you are using something like 'rubocop-github' or if you don't
-# want to list out extensions with the `rubocop_extensions` key.
+# want to list out dependencies with the `versions` key.
 # Valid options: true || false
 # Default: false
 bundle: false
@@ -66,12 +64,11 @@ check_scope: 'modified'
 ```yml
 # .github/config/rubocop_linter_action.yml
 
-rubocop_version: 'latest'
-rubocop_extensions:
-  - 'rubocop-rails'
-  - 'rubocop-performance': '1.5.1'
-  - 'rubocop-minitest': 'latest'
-  - 'rubocop-rspec': '1.37.0'
+versions:
+  - rubocop-rails
+  - rubocop-performance: '1.5.1'
+  - rubocop-minitest: 'latest'
+  - rubocop-rspec: '1.37.0'
 ```
 
 

--- a/lib/install.rb
+++ b/lib/install.rb
@@ -12,14 +12,13 @@ class Install
   def run
     return system("bundle install") if config.fetch("bundle", false)
 
-    system("gem install #{versions}")
+    system("gem install #{dependencies}")
   end
 
   private
 
-  def versions
-    gems = config.fetch("versions", DEFAULT_DEPENDENCIES)
-    dependencies = gems.map(&method(:dependency)).join(" ")
+  def dependencies
+    config.fetch("versions", DEFAULT_DEPENDENCIES).map(&method(:dependency)).join(" ")
   end
 
   def dependency(gem)

--- a/lib/install.rb
+++ b/lib/install.rb
@@ -22,17 +22,17 @@ class Install
   end
 
   def versions
-    extensions = config.fetch("versions", [])
-    command = []
-    extensions.each do |gem|
-      if gem.is_a? String
-        command << gem
-      else
-        gem_name = gem.keys.first
-        gem_version = gem.values.first
-        command << "#{gem_name}#{gem_version == 'latest' ? '' : ":#{gem_version}"}"
-      end
+    gems = config.fetch("versions", [])
+    dependencies = gems.map(&method(:dependency)).join(" ")
+  end
+
+  def dependency(gem)
+    case gem
+    when Hash
+      name, version = gem.first
+      version == "latest" ? name : "#{name}:#{version}"
+    else
+      gem
     end
-    command.join(" ")
   end
 end

--- a/lib/install.rb
+++ b/lib/install.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Install
+  DEFAULT_DEPENDENCIES = %w[rubocop].freeze
+
   attr_reader :config
 
   def initialize(config)
@@ -16,7 +18,7 @@ class Install
   private
 
   def versions
-    gems = config.fetch("versions", %w[rubocop])
+    gems = config.fetch("versions", DEFAULT_DEPENDENCIES)
     dependencies = gems.map(&method(:dependency)).join(" ")
   end
 

--- a/lib/install.rb
+++ b/lib/install.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Install
-  DEFAULT_DEPENDENCIES = %w[rubocop].freeze
+  DEFAULT_DEPENDENCIES = {
+    "rubocop" => "latest"
+  }.freeze
 
   attr_reader :config
 
@@ -18,16 +20,23 @@ class Install
   private
 
   def dependencies
-    config.fetch("versions", DEFAULT_DEPENDENCIES).map(&method(:dependency)).join(" ")
+    DEFAULT_DEPENDENCIES.merge(custom_dependencies).map(&method(:version_string)).join(" ")
   end
 
-  def dependency(gem)
-    case gem
+  def custom_dependencies
+    Hash[config.fetch("versions", []).map(&method(:version))]
+  end
+
+  def version(dependency)
+    case dependency
     when Hash
-      name, version = gem.first
-      version == "latest" ? name : "#{name}:#{version}"
+      dependency.first
     else
-      gem
+      [dependency, "latest"]
     end
+  end
+
+  def version_string(dependency, version)
+    version == "latest" ? dependency : "#{dependency}:#{version}"
   end
 end

--- a/lib/install.rb
+++ b/lib/install.rb
@@ -2,6 +2,7 @@
 
 class Install
   attr_reader :config
+
   def initialize(config)
     @config = config
   end
@@ -17,18 +18,11 @@ class Install
   def install_gems
     return system("bundle install") if config.fetch("bundle", false)
 
-    system("gem install #{rubocop} #{extensions}")
+    system("gem install #{versions}")
   end
 
-  def rubocop
-    version = config.fetch("rubocop_version", "latest")
-    return "rubocop" if version == "latest"
-
-    "rubocop:#{version}"
-  end
-
-  def extensions
-    extensions = config.fetch("rubocop_extensions", [])
+  def versions
+    extensions = config.fetch("versions", [])
     command = []
     extensions.each do |gem|
       if gem.is_a? String

--- a/lib/install.rb
+++ b/lib/install.rb
@@ -4,25 +4,19 @@ class Install
   attr_reader :config
 
   def initialize(config)
-    @config = config
+    @config = Hash(config)
   end
 
   def run
-    return system("gem install rubocop") unless config
-
-    install_gems
-  end
-
-  private
-
-  def install_gems
     return system("bundle install") if config.fetch("bundle", false)
 
     system("gem install #{versions}")
   end
 
+  private
+
   def versions
-    gems = config.fetch("versions", [])
+    gems = config.fetch("versions", %w[rubocop])
     dependencies = gems.map(&method(:dependency)).join(" ")
   end
 

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -1,10 +1,10 @@
-check_name: "Rubocop Results"
-rubocop_version: 'latest'
-rubocop_extensions:
-  - 'rubocop-rails'
-  - 'rubocop-performance': '1.5.1'
-  - 'rubocop-minitest': 'latest'
-  - 'rubocop-rspec': '1.37.0'
+check_name: 'Rubocop Results'
+versions:
+  - rubocop
+  - rubocop-rails
+  - rubocop-performance: '1.5.1'
+  - rubocop-minitest: 'latest'
+  - rubocop-rspec: '1.37.0'
 rubocop_config_path: '.rubocop.yml'
 rubocop_excluded_cops:
   - 'Style/FrozenStringLiteralComment'

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -18,6 +18,16 @@ describe Install do
       it { expect(subject).to have_received(:system).with("gem install rubocop") }
     end
 
+    context "when it's set to resolve dependencies through bundler" do
+      let(:config_file) do
+        <<~YAML
+          bundle: true
+        YAML
+      end
+
+      it { expect(subject).to have_received(:system).with("bundle install") }
+    end
+
     context "when there's no version specified" do
       let(:config_file) do
         <<~YAML

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -43,13 +43,13 @@ describe Install do
       let(:config_file) do
         <<~YAML
           versions:
-            - rubocop: latest
+            - rubocop: 0.79.0
             - rubocop-rails
-            - rubocop-rspec: 1.37.0
+            - rubocop-rspec: latest
         YAML
       end
 
-      it { expect(subject).to have_received(:system).with("gem install rubocop rubocop-rails rubocop-rspec:1.37.0") }
+      it { expect(subject).to have_received(:system).with("gem install rubocop:0.79.0 rubocop-rails rubocop-rspec") }
 
       context "when 'rubocop' is not included in the dependencies" do
         let(:config_file) do

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "./spec/spec_helper"
+
+describe Install do
+  subject { described_class.new(config) }
+
+  let(:config) { YAML.safe_load(config_file) }
+
+  before { allow(subject).to receive(:system) }
+
+  describe "#run" do
+    before { subject.run }
+
+    context "when there's no configuration" do
+      let(:config_file) { "" }
+
+      it { expect(subject).to have_received(:system).with("gem install rubocop") }
+    end
+
+    context "when there's no version specified" do
+      let(:config_file) do
+        <<~YAML
+          versions:
+            - rubocop
+        YAML
+      end
+
+      it { expect(subject).to have_received(:system).with("gem install rubocop") }
+    end
+
+    context "when the versions are specified" do
+      let(:config_file) do
+        <<~YAML
+          versions:
+            - rubocop: latest
+            - rubocop-rails
+            - rubocop-rspec: 1.37.0
+        YAML
+      end
+
+      it { expect(subject).to have_received(:system).with("gem install rubocop rubocop-rails rubocop-rspec:1.37.0") }
+    end
+  end
+end

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -40,6 +40,18 @@ describe Install do
       end
 
       it { expect(subject).to have_received(:system).with("gem install rubocop rubocop-rails rubocop-rspec:1.37.0") }
+
+      context "when 'rubocop' is not included in the dependencies" do
+        let(:config_file) do
+          <<~YAML
+            versions:
+              - rubocop-rails
+              - rubocop-rspec: 1.37.0
+          YAML
+        end
+
+        it { expect(subject).to have_received(:system).with("gem install rubocop rubocop-rails rubocop-rspec:1.37.0") }
+      end
     end
   end
 end


### PR DESCRIPTION
# Enhancement
## Description

Enables setting all dependency requirements under the same configuration key. If the key is not set or `rubocop` is omitted, then it is resolved to the latest version available.

Fixes #93 

## Why should this be added

This will streamline the configuration and the documentation. Adds test coverage to the dependency resolution logic.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
