### PR TITLE
tweak the way we read the config file

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -9,12 +9,12 @@ class Configuration
   end
 
   def build
-    Util.read_yaml(config_path)
+    Util.read_yaml("#{workspace}/#{config_path}")
   end
 
   private
 
   def config_path
-    "#{workspace}/#{ENV['INPUT_ACTION_CONFIG_PATH'] || DEFAULT_CONFIG_PATH}"
+    ENV["INPUT_ACTION_CONFIG_PATH"] || DEFAULT_CONFIG_PATH
   end
 end


### PR DESCRIPTION
# Bug fix

## Description

Update the way we grab the config file. 

## Why should this be added

It may correctly resolve as is but now it uses the workspace root whether the action config path input is given or not.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
