### PR TITLE
issue 96 exploration

### DIFF
--- a/lib/github/client.rb
+++ b/lib/github/client.rb
@@ -9,16 +9,18 @@ module Github
       @user_agent = user_agent
     end
 
-    def patch(url, body = {})
-      request_http do |http|
-        http.patch(url, body.to_json, headers)
+    def send_request(url: "", method: "patch", body: {}, cancel_request: false)
+      response = request_http do |http|
+        if method == "patch"
+          http.patch(url, body.to_json, headers)
+        else
+          http.post(url, body.to_json, headers)
+        end
       end
-    end
+      # Raise if this a request to cancel the check run to prevent a potential infinite loop
+      raise "#{response.code}: #{response.message}: #{response.body}" if cancel_request
 
-    def post(url, body = {})
-      request_http do |http|
-        http.post(url, body.to_json, headers)
-      end
+      message_handler(response: response, url: url)
     end
 
     private
@@ -35,10 +37,32 @@ module Github
     def request_http
       http = Net::HTTP.new("api.github.com", 443)
       http.use_ssl = true
-      response = yield(http)
-      raise "#{response.message}: #{response.body}" if response.code.to_i >= 300
+      yield(http)
+    end
 
-      JSON.parse(response.body)
+    def message_handler(response: {}, url: nil)
+      body = JSON.parse(response.body)
+      # Patch requests should return 200, Post request should return 200
+      # See: https://developer.github.com/v3/checks/runs/
+      return body if (response.code.to_i == 200) || (response.code.to_i == 201)
+
+      # If request response code is not 200 || 201, send a request to cancel the check run suite.
+      # See: https://bit.ly/2QLoFKx
+      send_request(
+        url: "#{url}/#{body['id']}",
+        body: cancel_suite_payload(body["name"], body["head_sha"]),
+        cancel_request: true
+      )
+    end
+
+    def cancel_suite_payload(name, head_sha)
+      {
+        name: name,
+        head_sha: head_sha,
+        status: "completed",
+        conclusion: "failure",
+        completed_at: Time.now.iso8601
+      }
     end
   end
 end


### PR DESCRIPTION
# Enhancement

## Description

- Send a request to cancel a created check run on a failed [!(201 || 200)] request
- Differentiate annotation updates and the completed update
- Output messages in the logs for:
  - New check runs
  - Updated check runs
  - Completed check runs

## Why should this be added

This will potentially address the issue raised in #96. Without more information on that specific issue it's hard to know but this will deinitely add some benefit regardless.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
