### PR TITLE
document the behavior of check_scope on commits to master

### DIFF
--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -44,7 +44,7 @@ rubocop_fail_level: 'warning'
 bundle: false
 
 # The scope of code that Rubocop should lint. Use this if you only want to lint changed files. If this is not set
-# or not equal to 'modified', Rubocop is run against the entire codebase.
+# or not equal to 'modified', Rubocop is run against the entire codebase. Note that this will not work on the master branch.
 # Valid options: 'modified'
 # Default: nil
 check_scope: 'modified'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ rubocop_fail_level: 'warning'
 bundle: false
 
 # The scope of code that Rubocop should lint. Use this if you only want to lint changed files. If this is not set
-# or not equal to 'modified', Rubocop is run against the entire codebase.
+# or not equal to 'modified', Rubocop is run against the entire codebase. Note that this will not work on the master branch.
 # Valid options: 'modified'
 # Default: nil
 check_scope: 'modified'

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,3 +13,13 @@ There is a bug with Checks that might cause your runs to get jumbled in the UI, 
 This is straight out of GitHub's documentation. Put simply, this action won't work correctly on pull requests from a forked repository as is.
 
 I am open to a PR that will just output the results of the RuboCop run to the actions log if someone would like to take a shot at adding that!
+
+**3. The modified flag is not working!**
+
+If you specify the following in your config file:
+
+```yaml
+check_scope: 'modified'
+```
+
+Please note that this will not work on commits to master. If you have an idea on how to make this work, please open an issue or PR!


### PR DESCRIPTION
# Documentation

## Description

Document that the value `modified` for `check_scope` will not work on commits to master.  It will only work on PR's that are comparing against master.

Fixes #105

## Why should this be added

Explain behavior that may not be immediately apparent.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
