### PR TITLE
Add postgresql-dev to the Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.7.0-alpine
 
-RUN apk --no-cache add build-base git
+RUN apk --no-cache add build-base postgresql-dev git
 
 LABEL "repository"="https://github.com/andrewmcodes/rubocop-linter-action"
 LABEL "maintainer"="Andrew Mason <andrewmcodes@protonmail.com>"


### PR DESCRIPTION
# Enhancement

## Description

This PR installs the `postgresql-dev` library into the action’s docker image, so that rails projects that use Postgres as their DB can run this action with `bundle: true` enabled.  

Rails, Docker, and Github Actions novice here, and I’ve got a rails project I’m working on and I’m setting it up with this action. I’m trying to keep all my gems’ versions explicitly managed in the Gemfile, so I set the bundle option to true in the action’s config so that it would run bundle install during each run.

  I’m also using Postgres as my database and when using Postgres in combination with the `bundle: true` setting, the action fails with the following error. Basically, the PostgreSQL libraries needed aren't available so bundle install can't complete successfully.

```
Fetching gem metadata from https://rubygems.org/..........
[IRRELEVANT LOG LINES REMOVED]
Fetching pg 1.2.2
Installing pg 1.2.2 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/pg-1.2.2/ext
/usr/local/bin/ruby -I /usr/local/lib/ruby/2.7.0 -r
./siteconf20200202-7-h52l51.rb extconf.rb
checking for pg_config... no
No pg_config... trying anyway. If building fails, please try again with
 --with-pg-config=/path/to/pg_config
checking for libpq-fe.h... no
Can't find the 'libpq-fe.h header
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/local/bin/$(RUBY_BASE_NAME)
	--with-pg
	--without-pg
	--enable-windows-cross
	--disable-windows-cross
	--with-pg-config
	--without-pg-config
	--with-pg_config
	--without-pg_config
	--with-pg-dir
	--without-pg-dir
	--with-pg-include
	--without-pg-include=${pg-dir}/include
	--with-pg-lib
	--without-pg-lib=${pg-dir}/lib

To see why this extension failed to compile, please check the mkmf.log which can
be found here:

  /usr/local/bundle/extensions/x86_64-linux-musl/2.7.0/pg-1.2.2/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/bundle/gems/pg-1.2.2 for
inspection.
Results logged to
/usr/local/bundle/extensions/x86_64-linux-musl/2.7.0/pg-1.2.2/gem_make.out

An error occurred while installing pg (1.2.2), and Bundler cannot continue.
Make sure that `gem install pg -v '1.2.2' --source 'https://rubygems.org/'`
succeeds before bundling.

In Gemfile:
  pg
/action/lib/results.rb:6:in ``': No such file or directory - rubocop (Errno::ENOENT)
	from /action/lib/results.rb:6:in `initialize'
	from /action/lib/report.rb:22:in `new'
	from /action/lib/report.rb:22:in `results'
	from /action/lib/report.rb:12:in `build'
	from /action/lib/github/check_run_service.rb:16:in `run'
	from /action/lib/index.rb:59:in `run_check_run_service'
	from /action/lib/index.rb:28:in `run'
	from /action/lib/index.rb:23:in `run'
	from /action/lib/index.rb:67:in `<main>'
##[error]Docker run failed with exit code 1
Cleaning up orphan processes
```

 [Here’s a repro repo I made](https://github.com/nathanshox/rubocop-linter-action-pg-db-reproduction). I’ve run the action a few times with various changes to illustrate what I’m running into.

-   [Run 1](https://github.com/nathanshox/rubocop-linter-action-pg-db-reproduction/actions/runs/34008483): Here I just cloned the repro template, and let the action run to verify everything was working expected at the outset.
- [Run 2](https://github.com/nathanshox/rubocop-linter-action-pg-db-reproduction/actions/runs/34011765): I switched the DB from Sqlite to PostgreSQL, and changed the workflow and configuration for the action to what I’m running in my project. This fails with the above error.
-  [Run 3](https://github.com/nathanshox/rubocop-linter-action-pg-db-reproduction/actions/runs/34012544): I switched the action to use the change I made to the docker file, and the action now completes fine, and I get results from rubocop.

  I realize this change is specific to using Postgres in Rails, and the docker image could become very large if everything that everyone could possible need was added. If there’s another way I can get this to work without modifying the image, I’d appreciate any pointers you might have that would help me in that direction. Other than that, considering Rails is a popular ruby framework and Postgres is a supported database option in Rails, maybe its worth adding for convenience?

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
