### PR TITLE
Ignore stderr when running the command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     minitest (5.14.0)
     multi_json (1.14.1)
     multipart-post (2.1.1)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.19.1)

--- a/lib/results.rb
+++ b/lib/results.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+require "open3"
+
 class Results
   attr_accessor :output, :status_code
+
   def initialize(command)
-    @output = `#{command}`
-    @status_code = $?.to_i # rubocop:disable Style/SpecialGlobalVars
+    Open3.popen2(command) do |stdin, stdout, thread|
+      stdin.close
+      @output = stdout.read
+      @status_code = thread.value.exitstatus
+    end
   end
 
   def build


### PR DESCRIPTION
## Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

When Rubocop has trouble parsing a file -- or has a bug -- it dumps
information into stderr in the form:

    An error occurred while Lint/DuplicatedKey cop was inspecting $file

This output gets included in the output of the `Command` that gets
parsed in the `Result` and causes a `JSON::ParserError` at
`lib/results.rb:18`.

By ignoring `stdout`, we can avoid this issue and continue on unabated.
Open3 seemed like the cleanest way to do this so I went in that
direction.

## Why should this be added

Errors in Rubocop shouldn't stop the action from working. This allows the action to ignore errors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing

## Questions

1. Do you want me to figure out a way to add a test for this? I wasn't sure how you'd like me to approach that since we're shelling out here to a Git repository.
