### PR TITLE
Do not use `xargs` to filter files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     minitest (5.14.0)
     multi_json (1.14.1)
     multipart-post (2.1.1)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.19.1)

--- a/lib/command.rb
+++ b/lib/command.rb
@@ -10,7 +10,7 @@ class Command
   def build
     return base_command unless config
 
-    "#{check_scope} #{base_command} #{fail_level} #{rubocop_config} #{excluded} #{force_exclusion}".strip.squeeze(" ")
+    "#{base_command} #{fail_level} #{rubocop_config} #{excluded} #{force_exclusion} #{check_scope}".strip.squeeze(" ")
   end
 
   private
@@ -20,7 +20,7 @@ class Command
   end
 
   def check_scope
-    return "git diff origin/master --name-only --diff-filter=AM | xargs" if config["check_scope"] == "modified"
+    return "-- $(git diff origin/master --name-only --diff-filter=AM)" if config["check_scope"] == "modified"
   end
 
   def rubocop_config

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -9,8 +9,14 @@ describe Command do
     it "returns built command" do
       command = Command.new(config).build
       expect(command).to eq(
-        "git diff origin/master --name-only --diff-filter=AM | xargs rubocop --parallel "\
-         "-f json --fail-level error -c .rubocop.yml --except Style/FrozenStringLiteralComment --force-exclusion"
+        "rubocop --parallel "\
+        "-f json "\
+        "--fail-level error "\
+        "-c .rubocop.yml "\
+        "--except Style/FrozenStringLiteralComment "\
+        "--force-exclusion "\
+        "-- "\
+        "$(git diff origin/master --name-only --diff-filter=AM)"
       )
     end
   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Using `xargs` makes it so more than one JSON document gets produced if
there are lints in more than one of the files. It also limits the
parallelization that Rubocop can do.

## Why should this be added

By explicitly naming the files that are changed, we can fix both of
these issues.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
