### PR TITLE
Allow passing `configuration.base_branch`

### DIFF
--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -56,3 +56,9 @@ bundle: false
 # Valid options: 'modified'
 # Default: nil
 check_scope: 'modified'
+
+# The base branch against which changes will be compared, if check_scope config is set to 'modified'.
+# This setting is not used if check_scope != 'modified'.
+# Valid options: 'origin/another_branch'
+# Default: 'origin/master'
+base_branch: 'origin/master'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,12 @@ bundle: false
 # Valid options: 'modified'
 # Default: nil
 check_scope: 'modified'
+
+# The base branch against which changes will be compared, if check_scope config is set to 'modified'.
+# This setting is not used if check_scope != 'modified'.
+# Valid options: 'origin/another_branch'
+# Default: 'origin/master'
+base_branch: 'origin/master'
 ```
 
 ## Example

--- a/lib/command.rb
+++ b/lib/command.rb
@@ -15,12 +15,16 @@ class Command
 
   private
 
+  def base_branch
+    config.fetch("base_branch", "origin/master")
+  end
+
   def base_command
     "rubocop --parallel -f json"
   end
 
   def check_scope
-    return "git diff origin/master --name-only --diff-filter=AM | xargs" if config["check_scope"] == "modified"
+    return "git diff #{base_branch} --name-only --diff-filter=AM | xargs" if config["check_scope"] == "modified"
   end
 
   def rubocop_config

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -9,7 +9,7 @@ describe Command do
     it "returns built command" do
       command = Command.new(config).build
       expect(command).to eq(
-        "git diff origin/master --name-only --diff-filter=AM | xargs rubocop --parallel "\
+        "git diff origin/develop --name-only --diff-filter=AM | xargs rubocop --parallel "\
          "-f json --fail-level error -c .rubocop.yml --except Style/FrozenStringLiteralComment --force-exclusion"
       )
     end

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -12,3 +12,4 @@ rubocop_fail_level: 'error'
 rubocop_force_exclusion: true
 bundle: false
 check_scope: 'modified'
+base_branch: 'origin/develop'


### PR DESCRIPTION
## Type of PR (feature, enhancement, bug fix, etc.)
Enhancement

## Description
I wanted to use this action with a repo I support, however our default branch is `origin/develop` rather than `origin/master`. 

I thought about replacing the `check_scope` configuration option with a `base_branch` option, and forcing users to enter a branch name to compare against, rather than checking for `config['check_scope'] == 'modified'`. However that would be a breaking change so I decided to go for a smaller, optional, non breaking change, although it's a nested configuration option. 

Fixes # (issue) [I didn't make an issue for this]

## Why should this be added

This allows more users to use this action only on the files changed in a given PR rather than against the whole repo. This option is useful for legacy codebases that may have lots of rubocop violations. 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Actions are passing
