### PR TITLE
Find modified files with respect to base commit of branch

### DIFF
--- a/lib/command.rb
+++ b/lib/command.rb
@@ -24,26 +24,28 @@ class Command
   end
 
   def check_scope
-    return "git diff #{base_branch} --name-only --diff-filter=AM | xargs" if config["check_scope"] == "modified"
+    return unless config["check_scope"] == "modified"
+
+    "git diff #{base_branch}... --name-only --diff-filter=AM | xargs"
   end
 
   def rubocop_config
     rubocop_config = config.fetch("rubocop_config_path", "")
-    return "-c #{rubocop_config}" unless rubocop_config.empty?
+    "-c #{rubocop_config}" unless rubocop_config.empty?
   end
 
   def excluded
     excluded_cops = config.fetch("rubocop_excluded_cops", "")
-    return "--except #{excluded_cops.join(' ')}" unless excluded_cops.empty?
+    "--except #{excluded_cops.join(' ')}" unless excluded_cops.empty?
   end
 
   def fail_level
     level = config.fetch("rubocop_fail_level", "")
-    return "--fail-level #{level}" unless level.empty?
+    "--fail-level #{level}" unless level.empty?
   end
 
   def force_exclusion
     force_exclusion = config.fetch("rubocop_force_exclusion", "").to_s
-    return "--force-exclusion" unless force_exclusion.empty? || force_exclusion == "false"
+    "--force-exclusion" unless force_exclusion.empty? || force_exclusion == "false"
   end
 end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -3,22 +3,113 @@
 require "./spec/spec_helper"
 
 describe Command do
-  let(:config) { YAML.safe_load(File.read("./spec/fixtures/config.yml")) }
+  subject(:command) { Command.new(config) }
 
-  context "when config file exists" do
-    it "returns built command" do
-      command = Command.new(config).build
-      expect(command).to eq(
-        "git diff origin/develop --name-only --diff-filter=AM | xargs rubocop --parallel "\
-         "-f json --fail-level error -c .rubocop.yml --except Style/FrozenStringLiteralComment --force-exclusion"
-      )
+  describe "#build" do
+    context "when config file exists" do
+      let(:config) { YAML.safe_load(config_file) }
+
+      context "with modified scope" do
+        let(:config_file) do
+          <<~YAML
+            check_scope: modified
+          YAML
+        end
+
+        context "when base_branch configuration option is specified" do
+          let(:config_file) do
+            <<~YAML
+              base_branch: origin/develop
+              check_scope: modified
+            YAML
+          end
+
+          it "uses base_branch for diff" do
+            expect(command.build).to eq(
+              "git diff origin/develop... --name-only --diff-filter=AM | xargs "\
+              "rubocop --parallel -f json"
+            )
+          end
+        end
+
+        context "when base_branch is not specified" do
+          it "defaults to origin/master" do
+            expect(command.build).to eq(
+              "git diff origin/master... --name-only --diff-filter=AM | xargs "\
+              "rubocop --parallel -f json"
+            )
+          end
+        end
+      end
+
+      context "with fail_level config" do
+        let(:config_file) do
+          <<~YAML
+            rubocop_fail_level: error
+          YAML
+        end
+
+        it "sets fail_level flag" do
+          expect(command.build).to eq("rubocop --parallel -f json --fail-level error")
+        end
+      end
+
+      context "with custom rubocop config file" do
+        let(:config_file) do
+          <<~YAML
+            rubocop_config_path: .rubocop.yml
+          YAML
+        end
+
+        it "sets correct flag for custom file" do
+          expect(command.build).to eq("rubocop --parallel -f json -c .rubocop.yml")
+        end
+      end
+
+      context "with excluded cops specified" do
+        let(:config_file) do
+          <<~YAML
+            rubocop_excluded_cops:
+              - Style/FrozenStringLiteralComment
+          YAML
+        end
+
+        it "excludes specified cops" do
+          expect(command.build).to eq("rubocop --parallel -f json --except Style/FrozenStringLiteralComment")
+        end
+      end
+
+      context "with force_exclusion config" do
+        let(:config_file) do
+          <<~YAML
+            rubocop_force_exclusion: true
+          YAML
+        end
+
+        it "sets force-exclusion flag" do
+          expect(command.build).to eq("rubocop --parallel -f json --force-exclusion")
+        end
+      end
+
+      context "with all options specified" do
+        let(:config_file) { File.read("./spec/fixtures/config.yml") }
+
+        it "returns built command" do
+          expect(command.build).to eq(
+            "git diff origin/develop... --name-only --diff-filter=AM | xargs "\
+            "rubocop --parallel -f json "\
+            "--fail-level error -c .rubocop.yml --except Style/FrozenStringLiteralComment --force-exclusion"
+          )
+        end
+      end
     end
   end
 
   context "when config file does not exist" do
+    let(:config) { nil }
+
     it "returns base command" do
-      command = Command.new(nil).build
-      expect(command).to eq("rubocop --parallel -f json")
+      expect(command.build).to eq("rubocop --parallel -f json")
     end
   end
 end


### PR DESCRIPTION
# Enhancement

## Description

The problem with `git diff origin/master` when detecting modified files is that more recent changes in master that the current branch is not aware of will also be included. The outcome is that RuboCop will end up warning about files that have been fixed in master but not touched in the current branch.

Using `git diff-tree` we can find only the files that changed in the current branch which feels more consistent with how GitHub produces the diff in a Pull Request.

## Why should this be added

With this enhancement, RuboCop will only perform checks on files that are listed in the PR.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
