### PR TITLE
remove shell_lint action

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -33,11 +33,3 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Run Rubocop
         run: bin/rubocop
-  shell_linter:
-    name: Shell Lint Action
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - uses: actions/checkout@master
-      - name: Run Shell Linter
-        uses: azohra/shell-linter@v0.1.0


### PR DESCRIPTION
# Bug Fix

## Description

We used to have a lot more of this in sh but now that there is almost nothing for this to check, and it's failing for unknown dependency issues, I think it is safe to move on from this lint for now.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
