### PR TITLE
Exit code if linter returns some failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Default usage, similar to running `gem install rubocop && rubocop` from your com
 ![Rubocop Linter Checks Overview][image1]
 ![Rubocop Linter File Annotation][image2]
 
-## Config option
+## Config options
+
+### exit_on_failure
 
 Stop the workflow execution if the linter returns some failures.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 <!-- Variables -->
 
 <!-- Files -->
+
 [changelog]: /CHANGELOG.md
 [coc]: /CODE_OF_CONDUCT.md
 [contributing]: /CONTRIBUTING.md
 [license]: /LICENSE.md
+
 <!-- Images -->
+
 [image1]: /screenshots/check-overview.png
 [image2]: /screenshots/file-annotation.png
 [logo]: /screenshots/rubocop-linter-action.png
@@ -61,6 +64,19 @@ Default usage, similar to running `gem install rubocop && rubocop` from your com
 ![Rubocop Linter Checks Overview][image1]
 ![Rubocop Linter File Annotation][image2]
 
+## Config option
+
+Stop the workflow execution if the linter returns some failures.
+
+```yaml
+- name: Rubocop Linter Action
+  uses: andrewmcodes/rubocop-linter-action@v3.2.0
+  with:
+    exit_on_failure: true
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## Community
 
 ### Changelog
@@ -113,6 +129,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Define a path to your optional action config file.'
     required: false
     default: '.github/config/rubocop_linter_action.yml'
+  exit_on_failure:
+    description: 'Return exit code if linter detect errors.'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: '.github/config/rubocop_linter_action.yml'
   exit_on_failure:
-    description: 'Return exit code if linter detect errors.'
+    description: 'Return exit code if linter returns some failures.'
     required: false
     default: false
 runs:

--- a/lib/github/check_run_service.rb
+++ b/lib/github/check_run_service.rb
@@ -17,6 +17,7 @@ module Github
       id, started_at = create_check
       update_check(id, started_at)
       complete_check(id, started_at)
+      success?
     end
 
     private
@@ -66,6 +67,10 @@ module Github
 
     def conclusion
       report_adapter.conclusion(results)
+    end
+
+    def success?
+      !report_adapter.failure?(results)
     end
 
     def endpoint_url

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -65,4 +65,4 @@ class RubocopLinterAction
 end
 
 success = RubocopLinterAction.run
-return exit 1 if ENV["INPUT_EXIT_ON_FAILURE"] && !success
+return exit 1 if [true, "true"].include?(ENV["INPUT_EXIT_ON_FAILURE"]) && !success

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -64,6 +64,4 @@ class RubocopLinterAction
   end
 end
 
-unless RubocopLinterAction.run
-  exit 1
-end
+exit 1 unless RubocopLinterAction.run

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -64,4 +64,6 @@ class RubocopLinterAction
   end
 end
 
-RubocopLinterAction.run
+unless RubocopLinterAction.run
+  exit 1
+end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -64,4 +64,5 @@ class RubocopLinterAction
   end
 end
 
-exit 1 unless RubocopLinterAction.run
+success = RubocopLinterAction.run
+return exit 1 if ENV["INPUT_EXIT_ON_FAILURE"] && !success

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -12,9 +12,13 @@ class ReportAdapter
     }.freeze
 
     def conclusion(report)
-      return CONCLUSION_TYPES[:failure] if status_code(report).positive?
+      return CONCLUSION_TYPES[:failure] if failure?(report)
 
       CONCLUSION_TYPES[:success]
+    end
+
+    def failure?(report)
+      status_code(report).positive?
     end
 
     def summary(report)

--- a/spec/github_check_run_service_spec.rb
+++ b/spec/github_check_run_service_spec.rb
@@ -21,6 +21,6 @@ describe Github::CheckRunService do
     stub_request(:any, "https://api.github.com/repos/owner/repository_name/check-runs")
       .to_return(status: 200, body: '{"id": "id", "__exit_code":1}')
 
-    expect(subject.run).to be_a(Hash)
+    expect(subject.run).to be_falsey
   end
 end


### PR DESCRIPTION
## Type of PR

- [ ] feature
- [X] enhancement
- [ ] bug fix
- [ ] other

## Description

Related with this issue: #148 

Return exit code if linter returns some failures

Config:
```yml
    - name: Rubocop Linter with exit code
      uses: andrewmcodes/rubocop-linter-action@rubocop-exit-code
      with:
        exit_on_failure: true
```

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Actions are passing
- [X] I have updated the documentation if applicable

## Tests

- [X] I have added tests
- [X] I have a sample app to demonstrate this is working and the link is: https://github.com/devmasxtest/rubocop-linter-action-148/blob/main/.github/workflows/rubocop_linter_action.yml
- [ ] I did not test it but I have a good reason.. (please let me know below :smile:)

<!-- Since it is hard to write great tests around some of the action's functionality - I do not expect every PR to have 100% test coverage if it does not make sense. However, if you have no tests, the next best thing is to create an example repo, point the action to your branch, and show that your fix does address the problem. -->
